### PR TITLE
Fixed aura bars position was on top of power bars

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -794,8 +794,8 @@ function unitframes.Layout(self,unit)
 	-- Auras
 	self.AuraBars = self.AuraBars or CreateFrame("Frame", nil, self)
 	self.AuraBars:SetHeight(2)
-	self.AuraBars:SetPoint("BOTTOMLEFT", self.Power, "TOPLEFT", 0, 6)
-	self.AuraBars:SetPoint("BOTTOMRIGHT", self.Power, "TOPRIGHT", 0, 6)
+	self.AuraBars:SetPoint("BOTTOMLEFT", self.Power, "TOPLEFT", 0, 10)
+	self.AuraBars:SetPoint("BOTTOMRIGHT", self.Power, "TOPRIGHT", 0, 10)
 	
 	-- Options
 	self.AuraBars.auraBarTexture = bdCore.media.flat


### PR DESCRIPTION
![wowscrnshot_050218_212416](https://user-images.githubusercontent.com/7860985/39557083-0caa1b70-4e53-11e8-9a59-74d79cecf747.jpg)

Can you update on Curse?

Thanks.